### PR TITLE
Enabled Tor control port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apk --no-cache --update add tor privoxy \
     && echo "forward-socks5 / 0.0.0.0:9050 ." >> /etc/privoxy/config \
     && sed -i 's/listen-address\s*127.0.0.1:8118/listen-address 0.0.0.0:8118/g' /etc/privoxy/config \
     && sed -i 's/#SOCKSPort 192.168.0.1:9100/SOCKSPort 0.0.0.0:9050/g' /etc/tor/torrc \
+    && sed -i 's/#ControlPort 9051/ControlPort 9051/g' /etc/tor/torrc \
     && rc-update add tor \
     && rc-update add privoxy
 
-EXPOSE 9050/tcp 8118/tcp
+EXPOSE 9050/tcp 9051/tcp 8118/tcp

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Alternately, you can manually launch the `tor-privoxy` container.
 ```bash
 docker run --name='tor-privoxy' -d \
   -p 9050:9050 \
+  -p 9051:9051 \
   -p 8118:8118 \
 dockage/tor-privoxy:latest
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,5 @@ tor-privoxy:
   image: dockage/tor-privoxy:latest
   ports:
     - "9050:9050" # Tor proxy
+    - "9051:9051" # Tor control port
     - "8118:8118" # Privoxy


### PR DESCRIPTION
Hey there,

thanks for this awesome image!

Tor offers a nice little API for it to be controlled by other applications, but it is not enabled by default. I need this for a project of mine, but I think others would benefit too - so I modified this repository to enable the port by default.