### PR TITLE
Added socat tunnel for the tor control port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,15 @@ LABEL org.label-schema.name="tor-privoxy" \
       org.label-schema.vcs-url="https://github.com/dockage/tor-privoxy" \
       org.label-schema.license="MIT"
 
-RUN apk --no-cache --update add tor privoxy \
+ADD socat.rc /etc/init.d/socat
+RUN apk --no-cache --update add tor privoxy socat \
     && mv /etc/tor/torrc.sample  /etc/tor/torrc \
     && echo "forward-socks5 / 0.0.0.0:9050 ." >> /etc/privoxy/config \
     && sed -i 's/listen-address\s*127.0.0.1:8118/listen-address 0.0.0.0:8118/g' /etc/privoxy/config \
     && sed -i 's/#SOCKSPort 192.168.0.1:9100/SOCKSPort 0.0.0.0:9050/g' /etc/tor/torrc \
-    && sed -i 's/#ControlPort 9051/ControlPort 9051/g' /etc/tor/torrc \
+    && sed -i 's/#ControlPort 9051/ControlPort 9052/g' /etc/tor/torrc \
     && rc-update add tor \
-    && rc-update add privoxy
+    && rc-update add privoxy \
+    && rc-update add socat
 
 EXPOSE 9050/tcp 9051/tcp 8118/tcp

--- a/socat.rc
+++ b/socat.rc
@@ -1,0 +1,9 @@
+#!/sbin/openrc-run
+
+description="Sets up socat relay for Tor control port."
+
+start() {
+    ebegin "Setting up Tor control relay"
+    socat -d tcp-listen:9051,reuseaddr,fork tcp:127.0.0.1:9052 &
+    eend $?
+}


### PR DESCRIPTION
This is an addition to my previous MR, #1.

Due to an error/simplification when testing I didn't notice that Tor does not accept connection to the ControlPort outside localhost (and any setting for changing the listener has been removed). For Docker this obviously creates a problem. This is why I added a socat traffic relay to fake localhost requests.

Sorry for not noticing this earlier!